### PR TITLE
[FIX] 이미지를 저장하는 방식 변경

### DIFF
--- a/app/src/main/java/com/example/click_accountbook/Database.kt
+++ b/app/src/main/java/com/example/click_accountbook/Database.kt
@@ -9,7 +9,7 @@ import java.util.*
 data class Image(
     @PrimaryKey @ColumnInfo(name = "id") val id: String,
     @ColumnInfo(name = "format") val format: String,
-    @ColumnInfo(name = "data") val data: ByteArray,
+    @ColumnInfo(name = "path") val path : String,
     @ColumnInfo(name = "timestamp") val timestamp: Date,
     @ColumnInfo(name = "receiptId") val receiptId: String
 )

--- a/app/src/main/java/com/example/click_accountbook/ReceiptOCR.kt
+++ b/app/src/main/java/com/example/click_accountbook/ReceiptOCR.kt
@@ -1,0 +1,4 @@
+package com.example.click_accountbook
+
+class ReceiptOCR {
+}


### PR DESCRIPTION
- 기존 방식 : 이미지를 DB 내 Image Table에 저장
- 현재 방식 : 이미지를 Android 내 drawalbe에 저장 후 DB 내 Image에는 path 및 정보만 저장

ex) 
1	1685008634554	jpg	/data/user/0/com.example.click_accountbook/files/1685008634554.jpg	1685008634562	1685008634554